### PR TITLE
ci: fix CI failures caused by golangci-lint incompatibility with Go 1.24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,22 +6,22 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Go 1.22
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: "1.22.x"
       - name: Display Go version
         run: go version
       - name: Code Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.55.2
+          version: v1.64.8
       - name: Build
         run: go build -v ./...
       - name: Test
         run: go test -coverprofile=coverage.out -covermode=atomic -v -race ./...
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,9 +14,9 @@ linters-settings:
       - performance
       - style
   govet:
-    check-shadowing: true
     enable:
       - fieldalignment
+      - shadow
   nolintlint:
     require-explanation: true
     require-specific: true
@@ -28,13 +28,12 @@ linters:
     - dogsled
     - dupl
     - errcheck
-    - exportloopref
     - exhaustive
     - goconst
     - gocritic
     - gofmt
     - goimports
-    - gomnd
+    - mnd
     - gocyclo
     - gosec
     - gosimple

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ func main() {
 				return err
 			}
 		}
+
 		return nil
 	})
 }


### PR DESCRIPTION
## Summary

- Upgrades `golangci/golangci-lint-action` from `v3` to `v6` and linter version from `v1.55.2` to `v1.64.8`
- Upgrades `actions/checkout` from `v3` to `v4`
- Upgrades `actions/setup-go` from `v3` to `v5`
- Upgrades `codecov/codecov-action` from `v3` to `v4`

## Root Cause

The CI workflow was pinned to `golangci-lint v1.55.2`, but Go's `toolchain auto` mode auto-upgraded the runtime to `go1.24.0` (newer than the `go 1.22.5` declared in `go.mod`). `golangci-lint v1.55.2` cannot read Go 1.24's export data format, causing:

```
internal error in importing "flag" (unsupported version: 2)
golangci-lint exit with code 3
```

This fix unblocks the dependabot PR #2 (grpc bump) and future CI runs.